### PR TITLE
Use double quotes when calling Elixir

### DIFF
--- a/src/rebar3_elixir_compile_util.erl
+++ b/src/rebar3_elixir_compile_util.erl
@@ -63,7 +63,7 @@ get_details(State) ->
 
     LibDir = case lists:keyfind(lib_dir, 1, Config) of
                 false -> 
-                    {ok, ElixirLibs_} = rebar_utils:sh("elixir -e 'IO.puts :code.lib_dir(:elixir)'", []),
+                    {ok, ElixirLibs_} = rebar_utils:sh("elixir -e \"IO.puts :code.lib_dir(:elixir)\"", []),
                     filename:join(re:replace(ElixirLibs_, "\\s+", "", [global,{return,list}]), "../");
                 {lib_dir, Dir2} -> Dir2
              end,            


### PR DESCRIPTION
The Windows `cmd.exe` doesn't handle single quotes, double quotes on the other hand are handled by both `cmd.exe` and `/bin/sh`, so this variant is more portable.