### PR TITLE
use project_plugins for rebar3_hex so it isn't fetched when a dep

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,2 @@
 {erl_opts, [debug_info]}.
-{plugins, [rebar3_hex]}.
+{project_plugins, [rebar3_hex]}.


### PR DESCRIPTION
This will keep it available without having to add to your global rebar3 config but also keep it from being fetched when `rebar3_elixir_compile` is used as a plugin for another project.