### PR TITLE
Added cdn option to elixir_opts. Fixed lib compilation for profiles other than dev.

### DIFF
--- a/src/rebar3_elixir_compile_util.erl
+++ b/src/rebar3_elixir_compile_util.erl
@@ -226,10 +226,7 @@ compile_libs(State, [App | Apps], AddToPath) ->
     AppDir = filename:join(rebar_state:get(State, elixir_base_dir), App), 
     Mix = rebar_state:get(State, mix),
     Env = rebar_state:get(State, mix_env),
-    Profile = case Env of
-        dev -> ""; 
-        prod -> "MIX_ENV=prod "
-    end,    
+    Profile = profile(Env),
     case {ec_file:exists(filename:join(AppDir, "mix.exs")), ec_file:exists(filename:join(AppDir, "rebar.config"))} of
         {true, false} -> 
             rebar_utils:sh(Profile ++ Mix ++ "deps.get", [{cd, AppDir}, {use_stdout, true}]),
@@ -242,6 +239,12 @@ compile_libs(State, [App | Apps], AddToPath) ->
         {false, _} -> State                 
     end,
     compile_libs(State, Apps, AddToPath).
+
+profile(Env) ->
+  case Env of
+    dev -> ""; 
+    prod -> "env MIX_ENV=" ++ atom_to_list(Env) ++ " "
+  end.   
 
 libs_dir(AppDir, Env) ->
     case filelib:is_dir(filename:join([AppDir, "_build", "shared" , "lib"])) of


### PR DESCRIPTION
Hello!

`rebar3_elixir_compile` is a great plugin and appeared to be very useful. Nevertheless, it has some defaults that did't fit. I have tried to generalize them.

### Added cdn option to elixir_opts.

Some companies tend to use a private repo for hex  tarballs, so I have introduced an optional `elixir_opts` setting, `cdn`, that can be used like this: 

```erlang
{elixir_opts, 
  [
    {env, prod},
    {cdn, "https://repo.hex.pm"}
  ]
}.
``` 

### Fixed lib compilation for profiles other than dev.

With `env` set to `prod`, one gets an error:

```
./rebar3 get-deps       
===> Verifying dependencies...
===> Fetching XXX
... so on
sh: line 0: exec: MIX_ENV=prod: not found
```

I have tried to fix this issue.


