### PR TITLE
Issue 27: Reset ERL_FLAGS before making rebar_utils:sh() calls

### DIFF
--- a/src/rebar3_elixir_compile_util.erl
+++ b/src/rebar3_elixir_compile_util.erl
@@ -63,7 +63,7 @@ get_details(State) ->
 
     LibDir = case lists:keyfind(lib_dir, 1, Config) of
                 false -> 
-                    {ok, ElixirLibs_} = rebar_utils:sh("elixir -e \"IO.puts :code.lib_dir(:elixir)\"", []),
+                    {ok, ElixirLibs_} = sh("elixir -e \"IO.puts :code.lib_dir(:elixir)\"", []),
                     filename:join(re:replace(ElixirLibs_, "\\s+", "", [global,{return,list}]), "../");
                 {lib_dir, Dir2} -> Dir2
              end,            
@@ -229,8 +229,8 @@ compile_libs(State, [App | Apps], AddToPath) ->
     Profile = profile(Env),
     case {ec_file:exists(filename:join(AppDir, "mix.exs")), ec_file:exists(filename:join(AppDir, "rebar.config"))} of
         {true, false} -> 
-            rebar_utils:sh(Profile ++ Mix ++ "deps.get", [{cd, AppDir}, {use_stdout, true}]),
-            rebar_utils:sh(Profile ++ Mix ++ "compile", [{cd, AppDir}, {use_stdout, true}]),
+            sh(Profile ++ Mix ++ "deps.get", [{cd, AppDir}, {use_stdout, true}]),
+            sh(Profile ++ Mix ++ "compile", [{cd, AppDir}, {use_stdout, true}]),
             LibsDir = libs_dir(AppDir, Env),
             {ok, Libs} = file:list_dir_all(LibsDir),
             transfer_libs(State, Libs, LibsDir);
@@ -282,3 +282,6 @@ maybe_copy_dir(Source, Target, CreateNew) ->
             ec_file:remove(TargetDir, [recurisve]),
             ec_file:copy(Source, TargetDir, [recursive])
     end.    
+
+sh(Command, Options) ->
+    rebar_utils:sh(Command, [{env, [{"ERL_FLAGS", ""}]} | Options]).

--- a/src/rebar3_elixir_compile_util.erl
+++ b/src/rebar3_elixir_compile_util.erl
@@ -34,13 +34,8 @@ add_deps_to_path(State, [App | Apps], Check) ->
                true -> 
                     case add_mix_locks(State2) of
                         {State2_, NewLock} -> 
-                            State2_1 = lists:foldl(fun
-                                (DepName, S) ->
-                                    DepPath = rebar_dir:deps_dir(State) ++ "/../lib/" ++ DepName ++ "/ebin",
-                                    rebar_state:update_code_paths(S, all_deps, [DepPath])
-                            end, State2_, get_deps_for_app(State2_, App)),
                             code:add_patha(Dir),
-                            rebar_state:set(State2_1, mixlock, NewLock);
+                            rebar_state:set(State2_, mixlock, NewLock);
                         _ -> State2
                     end;
                 false ->
@@ -48,14 +43,6 @@ add_deps_to_path(State, [App | Apps], Check) ->
                     State2
              end, 
     add_deps_to_path(State3, Apps, Check).
-
-get_deps_for_app(State, App) ->
-    AppDir = filename:join(filename:join(rebar_dir:root_dir(State), "_elixir_build/"), App),
-    Env = rebar_state:get(State, mix_env, "dev"),
-    case file:list_dir_all(libs_dir(AppDir, Env)) of
-        {ok, Libs} -> Libs;
-        _ -> []
-    end.
 
 add_elixir(State) ->
     {BinDir, Env, Config, LibDir} = rebar3_elixir_compile_util:get_details(State),
@@ -178,7 +165,7 @@ convert_lock(_Lock, [], _Level) ->
 
 convert_lock(Lock, [Dep | Deps], Level) ->
     case Dep of
-        {Name, {hex, Pkg, Vsn, _Hash, _Manager, SubDeps}} ->
+        {Name, {hex, Pkg, Vsn, _Hash, _Manager, SubDeps, _}} ->
             RebarDep = {rebar3_elixir_compile_util:to_binary(Name), {elixir, rebar3_elixir_compile_util:to_string(Pkg), rebar3_elixir_compile_util:to_string(Vsn)}, Level},
             case {SubDeps, is_app_in_code_path(Name)} of
               {[], true} ->


### PR DESCRIPTION
Make a wrapper for rebar_utils:sh() so that this plugin can invoke elixir/mix commands with ERL_FLAGS set to "". This is done so that the settings of ERL_FLAGS do not influence these commands.

For more information refer to: Issue 27, https://github.com/barrel-db/rebar3_elixir_compile/issues/27