### PR TITLE
Package name and version are binary strings in rebar.lock

### DIFF
--- a/src/rebar3_elixir_compile_resource.erl
+++ b/src/rebar3_elixir_compile_resource.erl
@@ -10,8 +10,8 @@
         ,needs_update/2
         ,make_vsn/1]).
 
-lock(_Dir, Source) ->
-    Source.
+lock(_Dir, {elixir, Name, Vsn}) ->
+    {elixir, rebar3_elixir_compile_util:to_binary(Name), rebar3_elixir_compile_util:to_binary(Vsn)}.
 
 download(Dir, {elixir, Name, _Vsn} = Pkg, State) ->
     {ok, Config} = file:consult(filename:join([rebar_dir:root_dir(State), "rebar.config"])),


### PR DESCRIPTION
Currently rebar.lock has a mix of binary & list types for packages names and versions strings. Erlang dependencies use binary strings while Elixir dependencies use list strings e.g.
```
{"1.1.0",
[{<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.2.2">>},0},
 {<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.1.0">>},1},
 {<<"mime">>,{elixir,"mime","1.0.0"},0},
 {<<"plug">>,{elixir,"plug","1.5.0"},0},
 {<<"ranch">>,{pkg,<<"ranch">>,<<"1.4.0">>},1}]}.
[
{pkg_hash,[
 {<<"cowboy">>, <<"6CDE634DA1DA8B1D17DD2B20F5F6F91AB8AC7FA1B5106D13DAD63C905AB76004">>},
 {<<"cowlib">>, <<"F73658B93DD043AF40400C3E4FD997068EBD0C617F8C8F4CD003A1A78EBF94F5">>},
 {<<"ranch">>, <<"10272F95DA79340FA7E8774BA7930B901713D272905D0012B06CA6D994F8826B">>}]}
].
```
This PR changes the way plugin puts resources in lock file.